### PR TITLE
Added support for --rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Minimalistic profile based screen manager for X. It allows to store current scre
 Tool may be usefull to people who work on the same laptop at home, in the office (different external displays and different screen setup) and on the go (no external display).
 
 Currently randrctl can
-* handle *mode*, *position*, *rotation* and *panning*
+* handle *mode*, *position*, *rotation*, *panning* and *rate*
 * dump current screen setup to a profile
 * automatically (via udev) or manually switch between stored profiles
 * list all available profiles and show profile details
@@ -77,6 +77,8 @@ Each property of ```outputs``` section references output as seen in xrandr (i.e.
 * ```panning``` — output panning (it's fun http://crunchbang.org/forums/viewtopic.php?id=20634). Value example: *"1366x1080"*
 
 * ```rotate``` — output rotation. Possible values: *"normal"*, *"left"*, *"right"*, *"inverted"*
+
+* ```rate``` — output refresh rate. Value example: *"60"*
 
 
 ### Primary

--- a/randrctl/model.py
+++ b/randrctl/model.py
@@ -36,11 +36,12 @@ class Rule:
 
 
 class Geometry:
-    def __init__(self, mode: str, pos: str='0x0', rotate: str='normal', panning: str='0x0'):
+    def __init__(self, mode: str, pos: str='0x0', rotate: str='normal', panning: str='0x0', rate: str='70'):
         self.mode = mode
         self.pos = pos
         self.rotate = rotate
         self.panning = panning
+        self.rate = rate
 
     def __repr__(self):
         return '+'.join([self.mode, self.pos.replace('x', '+')])
@@ -50,10 +51,11 @@ class Geometry:
             and self.mode == other.mode \
             and self.pos == other.pos \
             and self.rotate == other.rotate \
-            and self.panning == other.panning
+            and self.panning == other.panning \
+            and self.rate == other.rate
 
     def __hash__(self):
-        return hash(self.mode) ^ hash(self.pos) ^ hash(self.rotate) ^ hash(self.panning)
+        return hash(self.mode) ^ hash(self.pos) ^ hash(self.rotate) ^ hash(self.panning) ^ hash(self.rate)
 
 
 class Output:

--- a/randrctl/xrandr.py
+++ b/randrctl/xrandr.py
@@ -21,6 +21,7 @@ class Xrandr:
     POS_KEY = "--pos"
     ROTATE_KEY = "--rotate"
     PANNING_KEY = "--panning"
+    RATE_KEY = "--rate"
     PRIMARY_KEY = "--primary"
     QUERY_KEY = "-q"
     VERBOSE_KEY = "--verbose"
@@ -74,6 +75,8 @@ class Xrandr:
             args.append(o.geometry.rotate)
             args.append(self.PANNING_KEY)
             args.append(o.geometry.panning)
+            args.append(self.RATE_KEY)
+            args.append(o.geometry.rate)
             if o.primary:
                 args.append(self.PRIMARY_KEY)
 


### PR DESCRIPTION
Since my new monitor at home is way to large to work with the default refresh rate chosen by xrandr, I need to lower the setting manually. This request addresses this issue.

Enhancement: randrctl default in now simply set to "70". This could probably be set more dynamically. 