### PR TITLE
Fix for incorrect scale with a rotated screen

### DIFF
--- a/randrctl/xrandr.py
+++ b/randrctl/xrandr.py
@@ -196,11 +196,18 @@ class Xrandr:
         panning = parsed.group('panning')
         geometry = parsed.group('geometry')
         size, pos = self._parse_geometry(geometry)
+
+        is_rotated = rotate in ['left', 'right']
+        if is_rotated:
+            size = 'x'.join(size.split('x')[::-1])
+
         scale = '1x1'
         if size != display.mode:
             dw, dh = map(lambda s: int(s), display.mode.split('x'))
             vw, vh = map(lambda s: int(s), size.split('x'))
             sw, sh = vw / dw, vh / dh
+            if is_rotated:
+                sw, sh = sh, sw
             scale = "{}x{}".format(sw, sh)
 
         viewport = Viewport(size, pos, rotate, panning, scale)


### PR DESCRIPTION
Hi

When I dumping a profile with an external screen rotated
(`xrandr --output HDMI1 --mode 1920x1080 --rotate right --right-of eDP1`)

`randrctl dump` gives me:

```
    "outputs": {
        "HDMI1": {
            "mode": "1920x1080",
            "panning": "0x0",
            "pos": "1920x0",
            "rate": 60,
            "rotate": "right",
            "scale": "0.5625x1.7777777777777777"
        }
        ...
```

`scale` should be "1x1" otherwise  resulting a weird behavior
```
HDMI1 connected 608x3414+1920+0 right (normal left inverted right x axis y axis) 480mm x 270mm
```

This commit should fixes this issue.