### PR TITLE
Enhancement: Adding a option to list matched profiles

### DIFF
--- a/randrctl/__main__.py
+++ b/randrctl/__main__.py
@@ -63,6 +63,8 @@ class Main:
         command_list = commands_parsers.add_parser(LIST, help='list available profiles')
         command_list.add_argument('-l', action='store_const', const=True, default=False,
                                   help='long listing', dest='long_listing')
+        command_list.add_argument('-s', action='store_const', const=True, default=False,
+                                  help='scored listing', dest='scored_listing')
 
         # dump
         command_dump = commands_parsers.add_parser(DUMP,
@@ -127,6 +129,8 @@ class Main:
     def list(self, args: argparse.Namespace):
         if args.long_listing:
             self.randrctl.list_all_long()
+        elif args.scored_listing:
+            self.randrctl.list_all_scored()
         else:
             self.randrctl.list_all()
 

--- a/randrctl/ctl.py
+++ b/randrctl/ctl.py
@@ -101,6 +101,19 @@ class RandrCtl:
             for o in p.outputs:
                 print('  ', o)
 
+    def list_all_scored(self):
+        """
+        List matched profiles with scores
+        """
+        profiles = self.profile_manager.read_all()
+        xrandr_outputs = self.xrandr.get_connected_outputs()
+
+        profileMatcher = ProfileMatcher()
+        matching = profileMatcher.match(profiles, xrandr_outputs)
+
+        for score, p in matching:
+            print(p.name, score)
+
 
 class Hook:
     """

--- a/randrctl/profile.py
+++ b/randrctl/profile.py
@@ -165,7 +165,7 @@ class ProfileMatcher:
         matching = []
         for p in profiles:
             score = self._calculate_profile_score(p, xrandr_outputs)
-            if score > 0:
+            if score >= 0:
                 matching.append((score, p))
         return sorted(matching, key=lambda x: (x[0], x[1].priority), reverse=True)
 

--- a/randrctl/profile.py
+++ b/randrctl/profile.py
@@ -167,8 +167,7 @@ class ProfileMatcher:
             score = self._calculate_profile_score(p, xrandr_outputs)
             if score >= 0:
                 matching.append((score, p))
-
-        return sorted(matching, key=lambda x: x[0])
+        return sorted(matching, key=lambda x: x[0], reverse=True)
 
 
     def find_best(self, available_profiles: list, xrandr_outputs: list):

--- a/randrctl/profile.py
+++ b/randrctl/profile.py
@@ -147,9 +147,9 @@ class ProfileMatcher:
     """
     Matches profile to xrandr connections
     """
-    def find_best(self, available_profiles: list, xrandr_outputs: list):
+    def match(self, available_profiles: list, xrandr_outputs: list):
         """
-        Find first matching profile across availableProfiles for actualConnections
+        return a sorted list of matched profiles
         """
         output_names = set(map(lambda o: o.name, xrandr_outputs))
 
@@ -167,6 +167,15 @@ class ProfileMatcher:
             score = self._calculate_profile_score(p, xrandr_outputs)
             if score >= 0:
                 matching.append((score, p))
+
+        return sorted(matching, key=lambda x: x[0])
+
+
+    def find_best(self, available_profiles: list, xrandr_outputs: list):
+        """
+        find first matching profile across availableprofiles for actualconnections
+        """
+        matching = self.match(available_profiles, xrandr_outputs)
         max_score = max([s[0] for s in matching])
         matching = list([m[1] for m in matching if m[0] == max_score])
 

--- a/randrctl/profile.py
+++ b/randrctl/profile.py
@@ -159,9 +159,6 @@ class ProfileMatcher:
 
         logger.debug("%d/%d profiles match outputs sets", len(profiles), len(available_profiles))
 
-        if len(profiles) == 0:
-            return None
-
         matching = []
         for p in profiles:
             score = self._calculate_profile_score(p, xrandr_outputs)
@@ -172,20 +169,17 @@ class ProfileMatcher:
 
     def find_best(self, available_profiles: list, xrandr_outputs: list):
         """
-        find first matching profile across availableprofiles for actualconnections
+        Find first matching profile across availableProfiles for actualConnections
         """
         matching = self.match(available_profiles, xrandr_outputs)
-        max_score = max([s[0] for s in matching])
-        matching = list([m[1] for m in matching if m[0] == max_score])
 
-        if len(matching) > 0:
-            logger.debug("Found %d profiles with maximum score %d", len(matching), max_score)
-            matching.sort(key=lambda x: x.priority, reverse=True)
-            p = matching[0]
-            logger.debug("Selected profile %s with score %d and priority %d", p.name, max_score, p.priority)
-            return p
-        else:
+        if not matching:
             return None
+
+        max_score, p = matching[0]
+        logger.debug("Found %d profiles with maximum score %d", len(matching), max_score)
+        logger.debug("Selected profile %s with score %d and priority %d", p.name, max_score, p.priority)
+        return p
 
     def _calculate_profile_score(self, p: Profile, xrandr_outputs: list):
         """

--- a/randrctl/profile.py
+++ b/randrctl/profile.py
@@ -165,7 +165,7 @@ class ProfileMatcher:
         matching = []
         for p in profiles:
             score = self._calculate_profile_score(p, xrandr_outputs)
-            if score >= 0:
+            if score > 0:
                 matching.append((score, p))
         return sorted(matching, key=lambda x: x[0], reverse=True)
 

--- a/randrctl/profile.py
+++ b/randrctl/profile.py
@@ -167,7 +167,7 @@ class ProfileMatcher:
             score = self._calculate_profile_score(p, xrandr_outputs)
             if score > 0:
                 matching.append((score, p))
-        return sorted(matching, key=lambda x: x[0], reverse=True)
+        return sorted(matching, key=lambda x: (x[0], x[1].priority), reverse=True)
 
 
     def find_best(self, available_profiles: list, xrandr_outputs: list):


### PR DESCRIPTION
This PR adds a option `randrctl list -s` to list matched profiles.

```
> randrctl list -s
office_dp1_normal 10
office_dp1 10
default 3
laptop-rot-right 1
```

I'm using this for several months with rofi and found it is quite convenient.  I have binded XF86Display to `randrctl auto` and Shift+XF86Display to:

    randrctl switch-to $(randrctl list -s | rofi -dmenu -p "randrctl switch-to " | cut -d" " -f1)

A quick screenshot to describe that:
![2018-01-17-182658_1920x1080_scrot](https://user-images.githubusercontent.com/888716/35038028-55619b32-fbb4-11e7-874f-a7b5d4c9762a.png)

There are some design choices can be discussed(for example, using space or tab as separator). Please take a look and feel free to review it.