### PR TITLE
Using YAML instead of INI files.

### DIFF
--- a/randrctl/ctl.py
+++ b/randrctl/ctl.py
@@ -245,9 +245,10 @@ class CtlFactory:
 
         elif ini_files:
           # Warning message indicating deprecation
-          logger.warning("INI configuration is deprecated and will be removed in next minor release")
-          logger.warning("Please convert %s to yaml format", ini_files[0])
-          logger.warning("Visit https://github.com/edio/randrctl#priorpost-hooks for details")
+          logger.warning(
+            "INI configuration is deprecated and will be removed in next minor release\n" +
+            "Please convert %s to yaml format\n" +
+            "Visit https://github.com/edio/randrctl#priorpost-hooks for details", ini_files[0]) 
 
 
           # Instantiate config parser


### PR DESCRIPTION
Made the changes for using YAML configuration files instead of INI, which enables multi line hooks

Apparently the ConfigParser was reading the system-wide config file and updating it with the user's hooks and such. This functionality is maintained by updating a dictionary with the user's values.