### PR TITLE
Wait for pre/post hook completion

### DIFF
--- a/randrctl/ctl.py
+++ b/randrctl/ctl.py
@@ -149,7 +149,7 @@ class Hook:
                 if err:
                     env["randr_error"] = err
                 logger.debug("Calling '%s'", hook)
-                subprocess.Popen(hook, env=env, shell=True)
+                subprocess.run(hook, env=env, shell=True)
             except Exception as e:
                 logger.warning("Error while executing hook '%s': %s", hook, str(e))
 


### PR DESCRIPTION
Currently, pre/post hooks are spawned with `Popen` and completion is not waited for, and xrandr is invoked immediately. This means that `pre_switch` might complete after `post_switch`. I have the following setup:

- `pre_switch` kills Polybar. Polybar does not always die on the first kill, so the script runs killall in a loop, waiting a second between killalls.
- `post_switch` starts Polybar

Of course, `pre_switch` takes longer than switching the profile due to the sleep, so `pre_switch` also kills the Polybar spawned by `post_switch`.

This PR replaces `Popen` with `run`, so that hooks are not run in parallel.