### PR TITLE
Restore /etc/randrctl System Directory Fallback

### DIFF
--- a/randrctl/cli.py
+++ b/randrctl/cli.py
@@ -295,7 +295,7 @@ def main():
                 randrctl = context.build(
                     display=display,
                     xauthority=xauthority,
-                    config_dirs=[path.join(owner.pw_dir, context.DEFAULT_CONFIG_LOCATION)]
+                    config_dirs=context.default_config_dirs(owner_home=owner.pw_dir),
                 )
                 result = cmd(randrctl, args)
                 # exit as soon as first execution succeeds

--- a/randrctl/context.py
+++ b/randrctl/context.py
@@ -14,15 +14,17 @@ logger = logging.getLogger(__name__)
 CONFIG_NAME = "config.yaml"
 PROFILE_DIR_NAME = "profiles"
 DEFAULT_CONFIG_LOCATION = ".config/randrctl"
+SYS_CONFIG_DIR = "/etc/randrctl"
 
 
-def default_config_dirs():
+def default_config_dirs(owner_home="$HOME"):
     """
     :return: default list of directories to look for a config in
     """
     # $HOME is guaranteed to exist on POSIX
     dirs = [
-        _recursive_expand(path.join('$HOME', DEFAULT_CONFIG_LOCATION))
+        _recursive_expand(path.join(owner_home, DEFAULT_CONFIG_LOCATION)),
+        SYS_CONFIG_DIR,
     ]
 
     # if XDG_CONFIG_HOME is defined, use it too

--- a/randrctl/context.py
+++ b/randrctl/context.py
@@ -61,12 +61,15 @@ def configs(config_dirs: list):
                     logger.warning("error reading configuration file %s", config_file)
 
 
-def build(display: str, xauthority: str = None, config_dirs: list = default_config_dirs()):
+def build(display: str, xauthority: str = None, config_dirs=None):
     """
     Builds a RandrCtl instance and all its dependencies given a list of config directories
     :param: display - display
     :return: new ready to use RandrCtl instance
     """
+    if config_dirs is None:
+        config_dirs = default_config_dirs()
+
     (primary_config_dir, config) = next(configs(config_dirs), (config_dirs[0], dict()))
 
     prior_switch = config.get('hooks', dict()).get('prior_switch', None)


### PR DESCRIPTION
This restores the previous behavior of checking the system configuration directory as a fallback to the user's local configuration. In other words, `/etc/randrctl` will only be used if the user does not have `$HOME/.config/randrctl` configured. 

Closes #20 

---

Migrating post 1.6 broke most of our setups, this restores the previous behavior and allows us to upgrade to the latest version of randrctl.

I opted not to implement the `--dir` option, mentioned in #20, to maintain compatibility with the default udev rule. 
